### PR TITLE
update with security context link

### DIFF
--- a/docs/helm-rabbitmq-db2/README.md
+++ b/docs/helm-rabbitmq-db2/README.md
@@ -210,7 +210,8 @@ To use the Senzing code, you must agree to the End User License Agreement (EULA)
     oc ................
     ```
 
-1. :pencil2: Environment variables for `securityContext` values.
+1. :pencil2: Environment variables for `securityContext` values. See
+   [Managing Security Context Constraints](https://docs.openshift.com/container-platform/4.3/authentication/managing-security-context-constraints.html) to determine the correct values.
    Example:
 
     ```console


### PR DESCRIPTION
Update with link to OpenShift Managing Security Context Constraints page

## Why was change needed

Provide link to OpenShift page to help customers determine the values of “runAsUser”, “runAsGroup”, and “fsGroup” values.


